### PR TITLE
Add kotlin-reflect dependency needed by TornadoFx

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.load.kotlin.signatures
 
 plugins {
-    kotlin("jvm") version "1.3.11"
+    kotlin("jvm") version "1.3.21"
     id("org.jetbrains.dokka") version "0.9.17"
     id("maven-publish")
     id("signing")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib-jdk8"))
+    compile(kotlin("reflect"))
     compile("com.jfoenix:jfoenix:8.0.8")
     compile("no.tornado:tornadofx:1.7.18") {
         exclude("org.jetbrains.kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 dependencies {
     compile(kotlin("stdlib-jdk8"))
     compile("com.jfoenix:jfoenix:8.0.8")
-    compile("no.tornado:tornadofx:1.7.17") {
+    compile("no.tornado:tornadofx:1.7.18") {
         exclude("org.jetbrains.kotlin")
     }
 }


### PR DESCRIPTION
Hi, 
Thanks for this library!
After I've tried to run some test apps I get some errors,  then I noticed that kotlin-reflect dependency is missing, so I added it and upgraded Kotlin and TornadoFx versions.
I hope this changes would be helpful! 